### PR TITLE
rdoctask unsupported, DOS newlines, typos

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ task :test => :check_dependencies
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/array_stats.rb
+++ b/lib/array_stats.rb
@@ -2,7 +2,7 @@ $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
 module ArrayStats
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end
 
 require "#{File.dirname(__FILE__)}/array_stats/float"

--- a/test/test_array_stats.rb
+++ b/test/test_array_stats.rb
@@ -54,7 +54,7 @@ class TestArrayStats < Test::Unit::TestCase
   end
   
   context "mean" do
-    should "return the mean for the array " do
+    should "return the mean for the array" do
       assert_equal 7, [2,4,6,8,10,12].mean
       assert_equal 25, [48,29,26,19,3].mean
     end

--- a/test/test_float_extensions.rb
+++ b/test/test_float_extensions.rb
@@ -20,12 +20,12 @@ class TestFloatExtensions < Test::Unit::TestCase
       assert_in_delta 0.2456, n.fractional_part, 0.00000001
     end
     
-    should "retrun the decimal parts, even if they are 0" do
+    should "return the decimal parts, even if they are 0" do
       n = 12.0
       assert_equal 0.0, n.fractional_part
     end
     
-    should "retrun the decimal as a positive number, even if the original float is negative" do
+    should "return the decimal as a positive number, even if the original float is negative" do
       n = -12.2399
       assert_in_delta 0.2399, n.fractional_part, 0.00000001
     end


### PR DESCRIPTION
Windows newlines on Rakefile.  There are other files formatted for Win if you want me to fix those.  You can reject the Rakefile if you don't like the Unix format.

However, in that same Rakefile, rake/rdoctask is unsupported in rake > 10.0.0.  Changed to rdoc/task.  So at least keep that.  :monkey_face: 

Other minor typos in test cases and an old 0.5.0 version number.
