### PR TITLE
reimplemented percentile algorithm

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ begin
     gem.email = "gems@benkoski.com"
     gem.homepage = "http://github.com/bkoski/array_stats"
     gem.authors = ["Ben Koski"]
-    gem.add_development_dependency "thoughtbot-shoulda", ">= 0"
+    gem.add_development_dependency "shoulda", ">= 0"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
   Jeweler::GemcutterTasks.new
@@ -42,7 +42,7 @@ task :test => :check_dependencies
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/array_stats.gemspec
+++ b/array_stats.gemspec
@@ -44,11 +44,11 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<thoughtbot-shoulda>, [">= 0"])
+      s.add_development_dependency(%q<shoulda>, [">= 0"])
     else
-      s.add_dependency(%q<thoughtbot-shoulda>, [">= 0"])
+      s.add_dependency(%q<shoulda>, [">= 0"])
     end
   else
-    s.add_dependency(%q<thoughtbot-shoulda>, [">= 0"])
+    s.add_dependency(%q<shoulda>, [">= 0"])
   end
 end

--- a/lib/array_stats/array_stats.rb
+++ b/lib/array_stats/array_stats.rb
@@ -36,9 +36,9 @@ module ArrayStats
 
       (rank.fractional_part * (sample_1 - sample_0)) + sample_0
     elsif rank.truncate == 0
-      self.first.to_f
+      sorted_array.first.to_f
     elsif rank.truncate == self.length
-      self.last.to_f
+      sorted_array.last.to_f
     end
   end
 

--- a/lib/array_stats/array_stats.rb
+++ b/lib/array_stats/array_stats.rb
@@ -1,10 +1,10 @@
 module ArrayStats
-  
+
   # Returns the sum of all elements in the array; 0 if array is empty
   def total_sum
     self.inject(0) {|sum, sample| sum += sample}
   end
-  
+
   # Returns the mean of all elements in array; nil if array is empty
   def mean
     if self.length == 0
@@ -18,7 +18,7 @@ module ArrayStats
   def median
     percentile(50)
   end
-  
+
   # Returns the percentile value for percentile _p_; nil if array is empty.
   #
   # _p_ should be expressed as an integer; <tt>percentile(90)</tt> returns the 90th percentile of the array.
@@ -27,17 +27,19 @@ module ArrayStats
   def percentile p
     sorted_array = self.sort
     rank = (p.to_f / 100) * (self.length + 1)
-    
-    if self.length == 0
-      return nil
-    elsif rank.fractional_part?
+
+    return nil if self.length == 0
+
+    if rank.truncate > 0 && rank.truncate < self.length
       sample_0 = sorted_array[rank.truncate - 1]
       sample_1 = sorted_array[rank.truncate]
 
-      return (rank.fractional_part * (sample_1 - sample_0)) + sample_0
-    else
-      return sorted_array[rank - 1]
-    end    
+      (rank.fractional_part * (sample_1 - sample_0)) + sample_0
+    elsif rank.truncate == 0
+      self.first.to_f
+    elsif rank.truncate == self.length
+      self.last.to_f
+    end
   end
-  
+
 end

--- a/test/test_array_stats.rb
+++ b/test/test_array_stats.rb
@@ -6,66 +6,70 @@ class TestArrayStats < Test::Unit::TestCase
     should "return the middle of the set if array length is odd" do
       assert_equal 15, [1,2,15,22,38].median
     end
-    
+
     should "return the average of the middle of the set if array length is even" do
       assert_equal 10, [1,6,14,22].median
     end
-    
+
     should "return nil if the array is empty" do
       assert_nil [].median
     end
-    
+
     should "sort an array before deriving the median" do
       assert_equal 20, [1,20,50,60,10].median
     end
   end
-  
-  context "percentile" do 
+
+  context "percentile" do
     should "choose the number at a particular rank if array divides cleanly" do
       assert_equal 36, [12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48].percentile(65)
     end
-    
+
     should "interpolate according to algorithm if array does not divide cleanly" do
       assert_equal 5.5, [3,5,7,8,9,11,13,15].percentile(25)
       assert_equal 95.1981, [95.1772,95.1567,95.1937,95.1959,95.1442,95.0610,95.1591,95.1195,95.1065,95.0925,95.1990,95.1682].percentile(90).round_to(0.0001)
     end
-    
+
     should "return nil if the array is empty" do
       assert_nil [].percentile(30)
     end
+
+    should "return float for array under 6 elements and high percentile" do
+      assert_kind_of Float, [1,2,3,4,5].percentile(85)
+    end
   end
-  
+
   context "total_sum" do
     should "return the sum of all elements in the array" do
       assert_equal 12, [2,4,6].total_sum
     end
-    
+
     should "return an integer if all elements are ints" do
       assert_kind_of Integer, [2,4,6].total_sum
     end
-    
+
     should "return a float if at least some of the elements are floats" do
       assert_kind_of Float, [2.5,3.5,6].total_sum
     end
-    
+
     should "return 0 if the array is empty" do
       assert_equal 0, [].total_sum
     end
   end
-  
+
   context "mean" do
     should "return the mean for the array " do
       assert_equal 7, [2,4,6,8,10,12].mean
       assert_equal 25, [48,29,26,19,3].mean
     end
-    
+
     should "return nil if the array is empty" do
       assert_nil [].mean
     end
   end
-  
-  
-  
+
+
+
 end
 
 


### PR DESCRIPTION
Updated to depend on shoulda instead of thoughtbot-shoulda.  

There was a missed use case where the rank contained a fractional part, but rank.truncate returned a value equal to the length of the array.  According to the algorithm in this case, the last item should be returned as opposed to calculating the percentile (which was resulting in a non-existent index)
